### PR TITLE
[feature] No more `d-none`

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <a class="logo" href="#">
       <img src="favicons/EPFL_Logo_184X53.svg" alt="Logo EPFL, École polytechnique fédérale de Lausanne" class="img-fluid">
     </a>
-    <ul aria-hidden="true" class="nav-header d-none d-xl-flex">
+    <ul aria-hidden="true" class="nav-header d-xl-flex" style="display: none;">
       <li id="menu-item-1">
         <a class="nav-item" href="https://www.epfl.ch/about/fr/">À propos</a>
       </li>
@@ -79,13 +79,13 @@
 
         <script src="script.js"></script>
         <div class="main-header">
-            <div class="alert alert-danger alert-dismissible fade show d-none" role="alert">
+            <div class="alert alert-danger alert-dismissible fade show" style="display: none;" role="alert">
                 <span class="danger-with-close"></span>
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                   <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div class="alert alert-warning alert-dismissible fade show d-none" role="alert">
+            <div class="alert alert-warning alert-dismissible fade show" style="display: none;" role="alert">
                 <span class="warning-with-close"></span>
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                   <span aria-hidden="true">&times;</span>
@@ -103,17 +103,17 @@
     
             <hr>
     
-            <div class="form-group accred-selection d-none">
+            <div class="form-group accred-selection" style="display: none;">
                 <label id="accreditation-label">Choose an accreditation</label>
                 <select id="select-accred" class="custom-select"></select>
             </div>
     
-            <div class="form-group accred-selection-phone d-none">
+            <div class="form-group accred-selection-phone" style="display: none;">
                 <label id="accreditation-phone-label">Choose a phone number for this accreditation</label>
                 <select id="select-accred-phone" class="custom-select"></select>
             </div>
         </div>
-        <hr class="accred-hr d-none">
+        <hr class="accred-hr" style="display: none;">
     
         <div class="signs">
             <div class="edit-div">
@@ -207,19 +207,19 @@
 
                     <table>
                         <tr>
-                            <td class="event-sign-img d-none" style="margin-right: 500px; border-right: 1px solid grey">
+                            <td class="event-sign-img" style="display: none; margin-right: 500px; border-right: 1px solid grey">
                                 <a href="https://www.epfl.ch/"><img src="https://web2018.epfl.ch/6.2.2/icons/epfl-logo.png"
                                     width="100" alt="EPFL logo"></a>
                                 <br>
                                 <img id="event-image" src="favicons/android-chrome-512x512.png" alt="" width="250" height="250">
                                 <br>
-                                <span class="social-medias-event d-none" height="15"
-                                    style="font-family:Helvetica, Arial, sans-serif; font-size:13px; color:#707070;"
+                                <span class="social-medias-event" height="15"
+                                    style="display: none; font-family:Helvetica, Arial, sans-serif; font-size:13px; color:#707070;"
                                     id="follow-social-media">
                                     Follow us on social media
                                 </span>
                                 <br>
-                                <span class="social-medias-event d-none" height="25">
+                                <span class="social-medias-event" style="display: none;" height="25">
                                     <a href="https://twitter.com/EPFL"><img border=0 width=15px height=15px
                                             src="https://epfl-nl-media.sos-ch-gva-2.exo.io/static/images/twitter.png" alt="Image"></a>
                                     <a href="https://www.facebook.com/epflcampus"><img border=0 width=15px height=15px
@@ -294,18 +294,18 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td class="free-area-td d-none" id="free-area-xl-td" height="55" style="font-family:Helvetica, Arial, sans-serif; font-size:13px; color:#707070;">
+                                            <td class="free-area-td" id="free-area-xl-td" height="55" style="display: none; font-family:Helvetica, Arial, sans-serif; font-size:13px; color:#707070;">
                                                 <span class="free-area" id="free-area-xl"></span>
                                             </td>
                                         </tr>
-                                        <tr class="social-medias d-none">
+                                        <tr class="social-medias" style="display: none;">
                                             <td height="15"
                                                 style="font-family:Helvetica, Arial, sans-serif; font-size:13px; color:#707070;"
                                                 id="follow-social-media">
                                                 Follow us on social media
                                             </td>
                                         </tr>
-                                        <tr class="social-medias d-none">
+                                        <tr class="social-medias" style="display: none;">
                                             <td height="25">
                                                 <a href="https://twitter.com/EPFL"><img border=0 width=15px height=15px
                                                         src="https://epfl-nl-media.sos-ch-gva-2.exo.io/static/images/twitter.png" alt="Image"></a>
@@ -338,7 +338,7 @@
             <div class="sign-l w-500" style="min-width: 450px; gap: 20vw;">
                 <div class="sign">
 
-                    <img class="event-sign-img d-none" src="favicons/android-chrome-512x512.png" alt="" height="250" width="250">
+                    <img class="event-sign-img" style="display: none;" src="favicons/android-chrome-512x512.png" alt="" height="250" width="250">
 
                     <table border="0" cellpadding="0" cellspacing="0" width="250">
                         <tbody>
@@ -382,7 +382,7 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td class="free-area-td d-none" height="55" style="font-family:Helvetica, Arial, sans-serif; font-size:13px; color:#707070;">
+                                <td class="free-area-td" height="55" style="display: none; font-family:Helvetica, Arial, sans-serif; font-size:13px; color:#707070;">
                                     <span class="free-area"></span>
                                 </td>
                             </tr>
@@ -400,7 +400,7 @@
             <div class="sign-m w-500" style="min-width: 450px; gap: 20vw;">
                 <div class="sign">
 
-                    <img class="event-sign-img d-none" src="favicons/android-chrome-512x512.png" alt="" height="250" width="250">
+                    <img class="event-sign-img" style="display: none;" src="favicons/android-chrome-512x512.png" alt="" height="250" width="250">
 
                     <table border="0" cellpadding="0" cellspacing="0" width="250">
                         <tbody>
@@ -419,7 +419,7 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td class="free-area-td d-none" height="55" style="font-family:Helvetica, Arial, sans-serif; font-size:13px; color:#707070;">
+                                <td class="free-area-td" height="55" style="display: none; font-family:Helvetica, Arial, sans-serif; font-size:13px; color:#707070;">
                                     <span class="free-area"></span>
                                 </td>
                             </tr>

--- a/script.js
+++ b/script.js
@@ -33,7 +33,7 @@ function generateAndChangeHTML(user, accreditation, addressData) {
 
     let phone = 0;
     if(user.accreds[accreditation].phoneList.length > 1) {
-        $('.accred-selection-phone').removeClass('d-none');
+        $('.accred-selection-phone').css('display', '');
         $('#select-accred-phone').empty();
 
         const accredPhoneSelect = document.getElementById('select-accred-phone')
@@ -55,7 +55,7 @@ function generateAndChangeHTML(user, accreditation, addressData) {
             phone = phoneValue;
         });
     } else {
-        $('.accred-selection-phone').addClass('d-none')
+        $('.accred-selection-phone').css('display', 'none')
         phone = 0;
     }
 
@@ -69,14 +69,14 @@ function getPeopleBySciper(value) {
     $.get(`https://search-api.epfl.ch/api/ldap?q=${value}&hl=${langParam}`, function( data ) {
         if(!data.length || data.length >= 2) {
             $('.danger-with-close').html('No unique match for this query')
-            $('.alert-danger').removeClass('d-none')
+            $('.alert-danger').css('display', '')
         } else {
             url.searchParams.set('sciper', value)
             window.history.pushState(null, '', url.toString())
             $.get(`https://search-backend.epfl.ch/api/address?q=${value}`, function( addressData ) {
                 if(data[0].accreds.length > 1) {
-                    $('.accred-selection').removeClass('d-none')
-                    $('.accred-hr').removeClass('d-none')
+                    $('.accred-selection').css('display', '')
+                    $('.accred-hr').css('display', '')
     
                     $('#select-accred').empty()
     
@@ -100,13 +100,13 @@ function getPeopleBySciper(value) {
                         generateAndChangeHTML(data[0], optionValue, addressData)
                     });
     
-                    $('.alert-danger').addClass('d-none')
+                    $('.alert-danger').css('display', 'none')
     
                 } else {
-                    $('.accred-selection').addClass('d-none')
-                    $('.accred-hr').addClass('d-none')
+                    $('.accred-selection').css('display', 'none')
+                    $('.accred-hr').css('display', 'none')
                     generateAndChangeHTML(data[0], 0, addressData)
-                    $('.alert-danger').addClass('d-none')
+                    $('.alert-danger').css('display', 'none')
                 }
             })
         }
@@ -249,15 +249,15 @@ function changeSocialMedias() {
 
     if(socialMediasParam == 'true') {
         if(signTypeParam == 'event') {
-            $('.social-medias-event').removeClass('d-none')
+            $('.social-medias-event').css('display', '')
         } else {
-            $('.social-medias').removeClass('d-none')
+            $('.social-medias').css('display', '')
         }
     } else if(socialMediasParam == 'false') {
         if(signTypeParam == 'event') {
-            $('.social-medias-event').addClass('d-none')
+            $('.social-medias-event').css('display', 'none')
         } else {
-            $('.social-medias').addClass('d-none')
+            $('.social-medias').css('display', 'none')
         }
     }
 }
@@ -320,7 +320,7 @@ $( document ).ready(async function() {
             $("#edit-button").addClass('edit-on')
             $("#edit-button").removeClass('edit-off')
 
-            $('#free-area-xl-td').removeClass('d-none')
+            $('#free-area-xl-td').css('display', '')
 
             $('.copy-button').attr('disabled', 'true')
             if(!$("#mobile-phone-input").val()) {
@@ -361,9 +361,9 @@ $( document ).ready(async function() {
             $('.free-area').html(tinymce.get('tiny').getContent().replace('<br>', '') == langsJSON[lang]['free-text-area'] ? '' : tinymce.get('tiny').getContent())
 
             if(!$('#free-area-xl').html()) {
-                $('.free-area-td').addClass('d-none')
+                $('.free-area-td').css('display', 'none')
             } else {
-                $('.free-area-td').removeClass('d-none')
+                $('.free-area-td').css('display', '')
             }
 
             $('.copy-button').removeAttr('disabled')
@@ -418,27 +418,27 @@ async function manageImageURL(url) {
         img.src = url;
         img.onload = () => {
             $('#event-image').attr('src', url)
-            $('.alert-danger').addClass('d-none')
+            $('.alert-danger').css('display', 'none')
 
             const { hostname } = new  URL(url)
             if(!hostname.includes('epfl.ch')) {
-                $('.alert-warning').removeClass('d-none')
+                $('.alert-warning').css('display', '')
                 $('.warning-with-close').html(`If your image is not
                 hosted on the epfl.ch domain, it is possible that
                 some of the collaborators will not be able to see the image in your emails.`)
             } else {
-                $('.alert-warning').addClass('d-none')
+                $('.alert-warning').css('display', 'none')
             }
         }
         img.onerror = () => {
             if(url) {
                 $('.danger-with-close').html('Please insert a valid image URL.')
-                $('.alert-danger').removeClass('d-none')
+                $('.alert-danger').css('display', '')
             } else {
-                $('.alert-danger').addClass('d-none')
+                $('.alert-danger').css('display', 'none')
             }
             $('#event-image').attr('src', 'favicons/android-chrome-512x512.png')
-            $('.alert-warning').addClass('d-none')
+            $('.alert-warning').css('display', 'none')
         }
       });
 }
@@ -448,13 +448,13 @@ async function manageSignType(signType) {
     let socialMediasParam = url.searchParams.get('socialMedias')
     if(signType == 'event') {
         $('.sign').addClass('d-flex align-items-center')
-        $('.event-sign-img').removeClass('d-none')
-        $('#event-img').removeClass('d-none')
-        $('.sign-l, .sign-m, .hide-if-event').addClass('d-none')
-        $('.epfl-sign-logo').addClass('d-none')
+        $('.event-sign-img').css('display', '')
+        $('#event-img').css('display', '')
+        $('.sign-l, .sign-m, .hide-if-event').css('display', 'none')
+        $('.epfl-sign-logo').css('display', 'none')
         if(socialMediasParam == 'true') {
-            $('.social-medias-event').removeClass('d-none')
-            $('.social-medias').addClass('d-none')
+            $('.social-medias-event').css('display', '')
+            $('.social-medias').css('display', 'none')
         }
 
         $('.sign-xl').css('gap', '5vw')
@@ -462,14 +462,14 @@ async function manageSignType(signType) {
         $('.sign-xl').addClass('w-750')
     } else if(signType == 'basic') {
         $('.sign').removeClass('d-flex align-items-center')
-        $('.event-sign-img').addClass('d-none')
-        $('#event-img').addClass('d-none')
-        $('.alert-danger').addClass('d-none')
-        $('.sign-l, .sign-m, .hide-if-event').removeClass('d-none')
-        $('.epfl-sign-logo').removeClass('d-none')
+        $('.event-sign-img').css('display', 'none')
+        $('#event-img').css('display', 'none')
+        $('.alert-danger').css('display', 'none')
+        $('.sign-l, .sign-m, .hide-if-event').css('display', '')
+        $('.epfl-sign-logo').css('display', '')
         if(socialMediasParam == 'true') {
-            $('.social-medias').removeClass('d-none')
-            $('.social-medias-event').addClass('d-none')
+            $('.social-medias').css('display', '')
+            $('.social-medias-event').css('display', 'none')
         }
 
         $('.sign-xl').css('gap', '20vw')


### PR DESCRIPTION
It caused bugs when copying signatures as HTML.
Using a true `display: none;` CSS is more efficient.

close #46 