### PR TITLE
[fix/feat] Working postal code

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,7 +277,9 @@
                                                             class="office-place-value" id="office-place-check-value" style="color:#FF0000;">Office place</span></a>
                                                 </span>
                                                 <br>
-                                                <span class="postal-code">CH-1015 Lausanne</span>
+                                                <span class="postal-code">1015 Lausanne</span>
+                                                <br>
+                                                <span>Switzerland</span>
                                             </td>
                                         </tr>
                                         <tr>
@@ -381,7 +383,9 @@
                                     <a class="office-place" href="https://plan.epfl.ch/" style="color:#FF0000; text-decoration:underline;"><span
                                             class="office-place-value" style="color:#FF0000;">Office place</span></a>
                                     <br>
-                                    <span class="postal-code">CH-1015 Lausanne</span>
+                                    <span class="postal-code">1015 Lausanne</span>
+                                    <br>
+                                    <span>Switzerland</span>
                                 </td>
                             </tr>
                             <tr>

--- a/script.js
+++ b/script.js
@@ -21,8 +21,7 @@ function changeHTML(user, accreditation, phoneValue, addressData) {
 
     if(addressData.accreds[accreditation].fullAddress) {
         let fullAddressArray = addressData.accreds[accreditation].fullAddress.split('$ ')
-        var result = fullAddressArray.findIndex((value) => { return value.startsWith('CH-');}, 'CH-')
-        $('.postal-code').html(addressData.accreds[accreditation].fullAddress.split('$ ')[result])
+        $('.postal-code').html(fullAddressArray.slice(-1)[0])
     } else {
         $('.postal-code').html('CH-1015 Lausanne')
     }


### PR DESCRIPTION
No more `CH-` before the postal code
Postal codes other than `1015 Lausanne` are now working.

close #57 